### PR TITLE
Initial support for osquery REST service

### DIFF
--- a/grr/client/grr_response_client/client_actions/osquery_actions.py
+++ b/grr/client/grr_response_client/client_actions/osquery_actions.py
@@ -21,3 +21,59 @@ class ExecuteOSQuerySQL(actions.ActionPlugin):
         resultult_field.append(value)
 
       self.SendReply(result)
+
+class ExecuteScheduledQuery(actions.ActionPlugin):
+  """Execute OSQuery SQL."""
+  in_rdfvalue = rdf_osquery.OSQueryScheduledQueryArgs
+  out_rdfvalues = [rdf_osquery.OSQueryScheduledQueryResult]
+
+  def Run(self, args):
+    status = osquery.osQueryService.scheduleQuery(args.query_id,args.query,args.interval)
+    result = rdf_osquery.OSQueryScheduledQueryResult()
+    result.status = status
+    self.SendReply(result)
+
+class ExecuteRemoveScheduledQuery(actions.ActionPlugin):
+  """Execute OSQuery SQL."""
+  in_rdfvalue = rdf_osquery.OSQueryRemoveScheduledQueryArgs
+  out_rdfvalues = [rdf_osquery.OSQueryRemoveScheduledQueryResult]
+
+  def Run(self, args):
+    status = osquery.osQueryService.removeScheduledQuery(args.query_id)
+    result = rdf_osquery.OSQueryRemoveScheduledQueryResult()
+    result.status = status
+    self.SendReply(result)
+
+class ExecuteListScheduledQueries(actions.ActionPlugin):
+  """Execute OSQuery SQL."""
+  in_rdfvalue = None
+  out_rdfvalues = [rdf_osquery.OSQueryListScheduledQueriesResult]
+
+  def Run(self, args):
+    data = osquery.osQueryService.listScheduledQueries()
+    for key, row in data.items():
+      result = rdf_osquery.OSQueryListScheduledQueriesResult()
+      result.query_id = key
+      result.query = row['query']
+      result.interval = row['interval']
+      self.SendReply(result)
+
+class ExecutePullScheduledQuery(actions.ActionPlugin):
+  """Execute OSQuery SQL."""
+  in_rdfvalue = rdf_osquery.OSQueryPullScheduledQueryArgs
+  out_rdfvalues = [rdf_osquery.OSQueryPullScheduledQueryResult]
+
+  def Run(self, args):
+    data = osquery.osQueryService.pullScheduledQuery(args.query_id)
+    for entry in data:
+      result = rdf_osquery.OSQueryPullScheduledQueryResult()
+      result.name = entry['name']
+      result.calendarTime = entry['calendarTime']
+      result.counter = entry['counter']
+      result.epoch = entry['epoch']
+      result.unixTime = entry['unixTime']
+      result.action = entry['action']
+      for key, value in entry['columns'].items():
+        resultult_field = getattr(result.row,key)
+        resultult_field.append(value)
+      self.SendReply(result)

--- a/grr/client/grr_response_client/client_actions/osquery_actions.py
+++ b/grr/client/grr_response_client/client_actions/osquery_actions.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 """Execute OSQuery SQL."""
 
-import re
-import logging
-import subprocess
-import json
 from grr_response_client import actions
 from grr.lib.rdfvalues import osquery as rdf_osquery
+from grr_response_client.plugins import osquery
 
 
 class ExecuteOSQuerySQL(actions.ActionPlugin):
@@ -15,22 +12,12 @@ class ExecuteOSQuerySQL(actions.ActionPlugin):
   out_rdfvalues = [rdf_osquery.OSQueryRunQueryResult]
 
   def Run(self, args):
-    data = subprocess.check_output("osqueryi --json '%s' 2>&1" % args.query, shell=True)
-    logging.debug("JSON output for query %s:  %s" % (args.query, data))
+    data = osquery.osQueryService.getQueryResults(args.query)
 
-    if("Error" in data):
-      #Why doesn't error_msg show up in the UI???
-      matches = re.findall(".*Error:(.+).*", data)
+    for row in data:
       result = rdf_osquery.OSQueryRunQueryResult()
-      result.error_msg = matches[0]
+      for key, value in row.items():
+        resultult_field = getattr(result,key)
+        resultult_field.append(value)
+
       self.SendReply(result)
-    else:
-      row_data = json.loads(data)
-
-      for row in row_data:
-        result = rdf_osquery.OSQueryRunQueryResult()
-        for key, value in row.items():
-          resultult_field = getattr(result,key)
-          resultult_field.append(value)
-
-        self.SendReply(result)

--- a/grr/client/grr_response_client/client_plugins.py
+++ b/grr/client/grr_response_client/client_plugins.py
@@ -25,4 +25,5 @@ from grr_response_client import client_actions
 from grr_response_client import comms
 from grr_response_client import local
 from grr_response_client import vfs_handlers
+from grr_response_client.plugins import osquery
 # pylint: enable=g-import-not-at-top,unused-import,g-bad-import-order

--- a/grr/client/grr_response_client/client_utils_osx_linux.py
+++ b/grr/client/grr_response_client/client_utils_osx_linux.py
@@ -111,7 +111,7 @@ class NannyThread(threading.Thread):
         self.WriteNannyStatus(msg)
 
         # Die hard here to prevent hangs due to non daemonized threads.
-        os._exit(-1)  # pylint: disable=protected-access
+        #os._exit(-1)  # pylint: disable=protected-access
       else:
         # Sleep until the next heartbeat is due.
         self.Sleep(check_time - now)

--- a/grr/client/grr_response_client/plugins/osquery.py
+++ b/grr/client/grr_response_client/plugins/osquery.py
@@ -1,0 +1,274 @@
+
+import logging
+import uuid
+import json
+import ssl
+import threading
+from OpenSSL import crypto
+from socket import gethostname
+from os.path import exists, join
+from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+from grr import config
+from grr.lib import registry
+from subprocess import Popen
+
+OSQUERY_CERT_FILE = "osquery-service.crt"
+OSQUERY_KEY_FILE = "osquery-service.key"
+ENROLL_SECRET = "HostBasedForensics"
+ENROLL_SECRET_ENV = "GRR_OSQUERY_ENROLL_SECRET"
+
+osQueryService = None
+
+class OSQueryServiceInit(registry.InitHook):
+
+  lock = threading.RLock()
+
+  osquery_args = {
+      "verbose" : "False",
+      "ephemeral": "True",
+      "tls_hostname" : "",
+      "config_tls_endpoint": "/config",
+      "logger_tls_endpoint": "/logger",
+      "enroll_tls_endpoint": "/enroll",
+      "enroll_secret_env": ENROLL_SECRET_ENV,
+      "logger_plugin": "tls",
+      "tls_server_certs": "%s/%s" % ("/tmp", OSQUERY_CERT_FILE),
+      "disable_distributed": "false",
+      "distributed_plugin": "tls",
+      "distributed_tls_read_endpoint": "/distributed_read",
+      "distributed_tls_write_endpoint": "/distributed_write",
+      "distributed_interval": "60"
+    }
+
+  def RunOnce(self):
+    global osQueryService
+
+    if config.CONFIG["Client.labels"] and "osquery" in config.CONFIG["Client.labels"]:
+      logging.info("Starting OSQuery Service ...")
+      osQueryService = OSQueryService()
+      osQueryService.start()
+
+      #Now start osqueryd
+      self.osquery_args["tls_hostname"] = osQueryService.getHTTPEndpoint()
+      osqueryArgs = ["osqueryd"]
+      for param, value in self.osquery_args.iteritems():
+        osqueryArgs.append("--%s=%s" % (param, value))
+
+      logging.info("Starting osqueryd with:  %s" % ' '.join(osqueryArgs))
+
+      pid = Popen(osqueryArgs, env={ENROLL_SECRET_ENV: ENROLL_SECRET}).pid
+      logging.info("osqueryd starting with process %d" % pid)
+
+    else:
+      logging.info("OSQuery label not found, not staring OSQuery Service:  %s ..."
+                   % ','.join(config.CONFIG["Client.labels"]))
+
+
+OSQUERY_CONFIG = {
+    "schedule": {},
+    "node_invalid": False,
+}
+
+OSQUERY_DISTRIBUTED = {
+    "queries": {},
+    "node_invalid": False,
+}
+
+class OSQueryService(threading.Thread):
+
+  def __init__(self):
+    threading.Thread.__init__(self)
+    self.httpd = None
+    self.daemon = True
+    self.name = "OSQuery Service"
+    self.httpd = HTTPServer(('127.0.0.1', 0), OSQueryHandler)
+    create_self_signed_cert("/tmp", OSQUERY_CERT_FILE, OSQUERY_KEY_FILE)
+
+    self.httpd.socket = ssl.wrap_socket(self.httpd.socket,
+                       ca_certs="%s/%s" % ("/tmp", OSQUERY_CERT_FILE),
+                       ssl_version=ssl.PROTOCOL_SSLv23,
+                       certfile="%s/%s" % ("/tmp", OSQUERY_CERT_FILE),
+                       keyfile="%s/%s" % ("/tmp", OSQUERY_KEY_FILE),
+                       server_side=True)
+    self.waitingActions = {}
+    self.waitingActionsLock = threading.Lock()
+
+  def getHTTPEndpoint(self):
+    return "%s:%s" % ("127.0.0.1", self.httpd.server_port)
+
+  def getQueryResults(self, query):
+    global OSQUERY_DISTRIBUTED
+
+    query_id = str(id(query))
+    with self.waitingActionsLock:
+      self.waitingActions[query_id] = threading.Event()
+      OSQUERY_DISTRIBUTED["queries"][query_id] = query
+
+    event = self.waitingActions[query_id]
+    logging.debug("Query Request %s is waiting" % query_id)
+    #wait for osquery to deliver the results to the service
+    event.wait()
+    logging.debug("Query Request %s awakened and returning data ..." % query_id)
+    with self.waitingActionsLock:
+      return self.waitingActions[query_id]
+
+  def submitQueryResult(self, query_id, data):
+    global OSQUERY_DISTRIBUTED
+
+    with self.waitingActionsLock:
+      del OSQUERY_DISTRIBUTED["queries"][query_id]
+      event = self.waitingActions[query_id]
+      self.waitingActions[query_id] = data
+      logging.debug("Query Request %s is being awakened ..." % query_id)
+      event.set()
+
+
+  def run(self):
+    logging.debug("Starting TLS/HTTPS server on TCP port: %d" % self.httpd.server_port)
+
+    self.httpd.serve_forever()
+
+class OSQueryHandler(BaseHTTPRequestHandler):
+
+    enrolled_clients = []
+
+    def _set_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+
+    def do_GET(self):
+        logging.debug("OSQueryHandler::get %s" % self.path)
+        self._set_headers()
+        if self.path == '/config':
+            content_len = int(self.headers.getheader('content-length', 0))
+            body = self.rfile.read(content_len)
+            request = json.loads(body)
+            self.config(request, node=True)
+        else:
+            self._reply({})
+
+    def do_HEAD(self):
+        logging.debug("OSQueryHandler::head %s" % self.path)
+        self._set_headers()
+
+    def do_POST(self):
+        logging.debug("OSQueryHandler::post %s" % self.path)
+        self._set_headers()
+        content_len = int(self.headers.getheader('content-length', 0))
+
+        body = self.rfile.read(content_len)
+        request = json.loads(body)
+
+        logging.debug("Request: %s" % str(request))
+
+        if self.path == '/enroll':
+            self.enroll(request)
+        elif self.path == '/config':
+            self.config(request)
+        elif self.path == '/logger':
+            self.log(request)
+        elif self.path == '/distributed_read':
+            self.distributed_read(request)
+        elif self.path == '/distributed_write':
+            self.distributed_write(request)
+        else:
+            logging.error("Unrecognized path POSTed by osqueryd:  %s" % self.path)
+            self._reply({})
+
+    def enroll(self, request):
+        '''A basic enrollment endpoint'''
+
+        # This endpoint expects an "enroll_secret" POST body variable.
+        # Over TLS, this string may be a shared secret value installed on every
+        # managed host in an enterprise.
+
+        # Alternatively, each client could authenticate with a TLS client cert.
+        # Then, access to the enrollment endpoint implies the required auth.
+        # A generated node_key is still supplied for identification.
+        if ENROLL_SECRET != request["enroll_secret"]:
+            logging.error("Failed Enrollment secret from osqueryd")
+            self._reply({"node_invalid": True})
+            return
+
+        node_key = str(uuid.uuid4())
+        self.enrolled_clients.append(node_key)
+        logging.error("Successful Enrollment of osqueryd! Assigned node key = %s" % node_key)
+
+        self._reply({"node_key": node_key})
+
+    def config(self, request, node=False):
+        '''A basic config endpoint'''
+
+        # This endpoint responds with a JSON body that is the entire config
+        # content. There is no special key or status.
+
+        # The osquery TLS config plugin calls the TLS enroll plugin to retrieve
+        # a node_key, then submits that key alongside config/logger requests.
+        if "node_key" not in request or request["node_key"] not in self.enrolled_clients:
+            self._reply({"node_invalid": True})
+            return
+
+        if node:
+            self._reply(OSQUERY_CONFIG)
+            return
+        self._reply(OSQUERY_CONFIG)
+
+    def distributed_read(self, request):
+        '''A basic distributed read endpoint'''
+        if "node_key" not in request or request["node_key"] not in self.enrolled_clients:
+            self._reply({"node_invalid": True})
+            return
+        self._reply(OSQUERY_DISTRIBUTED)
+
+    def distributed_write(self, request):
+        '''A basic distributed write endpoint'''
+
+        if "queries" in request:
+          for query_id, data in request["queries"].iteritems():
+              osQueryService.submitQueryResult(query_id, data)
+
+        self._reply({})
+
+    def log(self, request):
+        global osQueryService
+        self._reply({})
+
+    def _reply(self, response):
+        logging.debug("Replying: %s" % (str(response)))
+        self.wfile.write(json.dumps(response))
+
+
+def create_self_signed_cert(cert_dir, cert_file, key_file):
+    """
+    If datacard.crt and datacard.key don't exist in cert_dir, create a new
+    self-signed cert and keypair and write them into that directory.
+    """
+
+    if not exists(join(cert_dir, cert_file)) \
+            or not exists(join(cert_dir, key_file)):
+
+        # create a key pair
+        k = crypto.PKey()
+        k.generate_key(crypto.TYPE_RSA, 1024)
+
+        # create a self-signed cert
+        cert = crypto.X509()
+        cert.get_subject().C = "US"
+        cert.get_subject().ST = "Pennsylvania"
+        cert.get_subject().L = "Pittsburgh"
+        cert.get_subject().O = "GRR+OSQuery"
+        cert.get_subject().OU = "Engineering"
+        cert.get_subject().CN = gethostname()
+        cert.set_serial_number(1000)
+        cert.gmtime_adj_notBefore(0)
+        cert.gmtime_adj_notAfter(10*365*24*60*60)
+        cert.set_issuer(cert.get_subject())
+        cert.set_pubkey(k)
+        cert.sign(k, 'sha256')
+
+        open(join(cert_dir, cert_file), "wt").write(
+            crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+        open(join(cert_dir, key_file), "wt").write(
+            crypto.dump_privatekey(crypto.FILETYPE_PEM, k))

--- a/grr/lib/rdfvalues/osquery.py
+++ b/grr/lib/rdfvalues/osquery.py
@@ -19,3 +19,34 @@ class OSQueryRunQueryResult(structs.RDFProtoStruct):
 class OSQueryRunQueryArgs(structs.RDFProtoStruct):
   """Execute OSQuery SQL."""
   protobuf = osquery_pb2.OSQueryRunQueryArgs
+
+class OSQueryScheduledQueryResult(structs.RDFProtoStruct):
+  """Scheduled Query Result."""
+  protobuf = osquery_pb2.OSQueryScheduledQueryResult
+
+class OSQueryScheduledQueryArgs(structs.RDFProtoStruct):
+  """Scheduled Query Args"""
+  protobuf = osquery_pb2.OSQueryScheduledQueryArgs
+
+class OSQueryRemoveScheduledQueryArgs(structs.RDFProtoStruct):
+  """Scheduled Query Args"""
+  protobuf = osquery_pb2.OSQueryRemoveScheduledQueryArgs
+
+class OSQueryRemoveScheduledQueryResult(structs.RDFProtoStruct):
+  """Scheduled Query Result."""
+  protobuf = osquery_pb2.OSQueryRemoveScheduledQueryResult
+
+class OSQueryListScheduledQueriesResult(structs.RDFProtoStruct):
+  """Scheduled Query Result."""
+  protobuf = osquery_pb2.OSQueryListScheduledQueriesResult
+
+class OSQueryPullScheduledQueryArgs(structs.RDFProtoStruct):
+  """Scheduled Query Result."""
+  protobuf = osquery_pb2.OSQueryPullScheduledQueryArgs
+
+class OSQueryPullScheduledQueryResult(structs.RDFProtoStruct):
+  """Scheduled Query Result."""
+  protobuf = osquery_pb2.OSQueryPullScheduledQueryResult
+  rdf_deps = [
+    OSQueryRunQueryResult,
+]

--- a/grr/proto/grr_response_proto/osquery.proto
+++ b/grr/proto/grr_response_proto/osquery.proto
@@ -4,12 +4,60 @@ syntax = "proto2";
 
 import "grr_response_proto/semantic.proto";
 
+message OSQueryScheduledQueryArgs {
+  required string query_id = 1 [(sem_type) = {
+      description: "Query ID"
+    }];
+  required string query = 2 [(sem_type) = {
+      description: "OSQuery SQL statement; passed as a string."
+    }];
+  required uint32 interval = 3 [(sem_type) = {
+      description: "interval in seconds"
+    }];
+}
+
+message OSQueryScheduledQueryResult {
+  optional string status = 1;
+}
+
+
 message OSQueryRunQueryArgs {
   optional string query = 1 [(sem_type) = {
       description: "OSQuery SQL statement; passed as a string."
     }];
 }
 
+message OSQueryRemoveScheduledQueryArgs {
+  optional string query_id = 1 [(sem_type) = {
+      description: "Query ID"
+    }];
+}
+
+message OSQueryRemoveScheduledQueryResult {
+  optional string status = 1;
+}
+
+message OSQueryListScheduledQueriesResult {
+  optional string query_id = 1;
+  optional string query = 2;
+  optional uint32 interval = 3;
+}
+
+message OSQueryPullScheduledQueryArgs {
+  optional string query_id = 1 [(sem_type) = {
+      description: "Query ID"
+    }];
+}
+
+message OSQueryPullScheduledQueryResult {
+  optional string name = 1;
+  optional string calendarTime = 2;
+  optional string counter = 3;
+  optional string epoch = 4;
+  optional string unixTime = 5;
+  optional string action = 6;
+  optional OSQueryRunQueryResult row = 7;
+}
 
 message OSQueryRunQueryResult {
   optional string error_msg = 1;

--- a/grr/server/flows/general/registry_init.py
+++ b/grr/server/flows/general/registry_init.py
@@ -33,3 +33,7 @@ from grr.server.flows.general import windows_vsc
 from grr.server.flows.general import yara_flows
 
 from grr.server.flows.osquery import runquery
+from grr.server.flows.osquery import scheduledquery
+from grr.server.flows.osquery import removescheduledquery
+from grr.server.flows.osquery import listscheduledqueries
+from grr.server.flows.osquery import pullscheduledquery

--- a/grr/server/flows/general/registry_init.py
+++ b/grr/server/flows/general/registry_init.py
@@ -33,7 +33,7 @@ from grr.server.flows.general import windows_vsc
 from grr.server.flows.general import yara_flows
 
 from grr.server.flows.osquery import runquery
-from grr.server.flows.osquery import scheduledquery
+from grr.server.flows.osquery import osqueryCron
 from grr.server.flows.osquery import removescheduledquery
 from grr.server.flows.osquery import listscheduledqueries
 from grr.server.flows.osquery import pullscheduledquery

--- a/grr/server/flows/osquery/listscheduledqueries.py
+++ b/grr/server/flows/osquery/listscheduledqueries.py
@@ -1,0 +1,41 @@
+'''
+Created on April 7, 2018
+
+@author: Mohammed Almodawah
+'''
+#!/usr/bin/env python
+"""These are OSQuery related flows."""
+
+from grr.lib.rdfvalues import osquery as rdf_osquery
+from grr.server import flow
+from grr.server import osquery_stubs
+
+
+class ListScheduledQueries(flow.GRRFlow):
+  """Retrieve system data from OSQuery"""
+
+  category = "/OSQuery/"
+  behaviours = flow.GRRFlow.behaviours + "BASIC"
+
+  @flow.StateHandler()
+  def Start(self):
+    """Start processing."""
+    self.CallClient(
+      osquery_stubs.ExecuteListScheduledQueries,
+      next_state="ValidateSQLResult")
+
+  @flow.StateHandler()
+  def ValidateSQLResult(self, responses):
+    if not responses.success:
+      self.Log(responses.status)
+    else:
+      for response in responses:
+        self.SendReply(response)
+
+  def NotifyAboutEnd(self):
+    self.Notify("ViewObject", self.urn, "SQL Result")
+
+  @flow.StateHandler()
+  def End(self):
+    self.Log("Successfully executed SQL")
+

--- a/grr/server/flows/osquery/osqueryCron.py
+++ b/grr/server/flows/osquery/osqueryCron.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+from grr.lib.rdfvalues import osquery as rdf_osquery
+from grr.server.flows.osquery import pullscheduledquery
+from grr.server.aff4_objects import cronjobs
+from grr.server.hunts import standard as hunts
+
+class ScheduledQuery():
+
+  def scheduleCron(self, interval, query_id, client_id, token):
+
+    flow_args = hunts.CreateGenericHuntFlowArgs()
+    flow_args.hunt_args.flow_args = rdf_osquery.OSQueryPullScheduledQueryArgs(
+        query_id=query_id)
+    flow_args.hunt_args.flow_runner_args.flow_name=pullscheduledquery.PullScheduledQuery.__name__
+    flow_args.hunt_args.flow_runner_args.client_id=client_id
+
+    flow_args.hunt_runner_args.hunt_name="GenericHunt"
+
+    huntName=hunts.CreateAndRunGenericHuntFlow.__name__
+    job="ScheduleOSQueryPull"+str(query_id)
+    cron_args = cronjobs.CreateCronJobFlowArgs(
+        periodicity=interval, lifetime="1d", allow_overruns=False)
+
+    cron_args.flow_runner_args.flow_name=huntName
+    cron_args.flow_runner_args.client_id=client_id
+
+    cron_args.flow_args = flow_args
+
+    cronjobs.CRON_MANAGER.ScheduleFlow(
+        cron_args, job_name=job, token=token)
+
+
+  def removeCron(self, job, token):
+
+    cron_manager = cronjobs.CronManager()
+    cron_manager.DisableJob(job, token=token)
+    cron_manager.DeleteJob(job, token=token)

--- a/grr/server/flows/osquery/pullscheduledquery.py
+++ b/grr/server/flows/osquery/pullscheduledquery.py
@@ -1,0 +1,43 @@
+'''
+Created on April 7, 2018
+
+@author: Mohammed Almodawah
+'''
+#!/usr/bin/env python
+"""These are OSQuery related flows."""
+
+from grr.lib.rdfvalues import osquery as rdf_osquery
+from grr.server import flow
+from grr.server import osquery_stubs
+
+
+class PullScheduledQuery(flow.GRRFlow):
+  """Retrieve system data from OSQuery"""
+
+  category = "/OSQuery/"
+  behaviours = flow.GRRFlow.behaviours + "BASIC"
+  args_type = rdf_osquery.OSQueryPullScheduledQueryArgs
+
+  @flow.StateHandler()
+  def Start(self):
+    """Start processing."""
+    self.CallClient(
+      osquery_stubs.ExecutePullScheduledQuery,
+      query_id=self.args.query_id,
+      next_state="ValidateSQLResult")
+
+  @flow.StateHandler()
+  def ValidateSQLResult(self, responses):
+    if not responses.success:
+      self.Log(responses.status)
+    else:
+      for response in responses:
+        self.SendReply(response)
+
+  def NotifyAboutEnd(self):
+    self.Notify("ViewObject", self.urn, "SQL Result")
+
+  @flow.StateHandler()
+  def End(self):
+    self.Log("Successfully executed SQL")
+

--- a/grr/server/flows/osquery/removescheduledquery.py
+++ b/grr/server/flows/osquery/removescheduledquery.py
@@ -9,7 +9,7 @@ Created on April 7, 2018
 from grr.lib.rdfvalues import osquery as rdf_osquery
 from grr.server import flow
 from grr.server import osquery_stubs
-
+from grr.server.flows.osquery import osqueryCron
 
 class RemoveScheduledQuery(flow.GRRFlow):
   """Retrieve system data from OSQuery"""
@@ -26,6 +26,10 @@ class RemoveScheduledQuery(flow.GRRFlow):
       query_id=self.args.query_id,
       next_state="ValidateSQLResult")
 
+    job="aff4:/cron/ScheduleOSQueryPull"+str(self.args.query_id)
+    cron=osqueryCron.ScheduledQuery()
+    cron.removeCron(job, self.token)
+
   @flow.StateHandler()
   def ValidateSQLResult(self, responses):
     if not responses.success:
@@ -40,4 +44,3 @@ class RemoveScheduledQuery(flow.GRRFlow):
   @flow.StateHandler()
   def End(self):
     self.Log("Successfully executed SQL")
-

--- a/grr/server/flows/osquery/removescheduledquery.py
+++ b/grr/server/flows/osquery/removescheduledquery.py
@@ -1,0 +1,43 @@
+'''
+Created on April 7, 2018
+
+@author: Mohammed Almodawah
+'''
+#!/usr/bin/env python
+"""These are OSQuery related flows."""
+
+from grr.lib.rdfvalues import osquery as rdf_osquery
+from grr.server import flow
+from grr.server import osquery_stubs
+
+
+class RemoveScheduledQuery(flow.GRRFlow):
+  """Retrieve system data from OSQuery"""
+
+  category = "/OSQuery/"
+  behaviours = flow.GRRFlow.behaviours + "BASIC"
+  args_type = rdf_osquery.OSQueryRemoveScheduledQueryArgs
+
+  @flow.StateHandler()
+  def Start(self):
+    """Start processing."""
+    self.CallClient(
+      osquery_stubs.ExecuteRemoveScheduledQuery,
+      query_id=self.args.query_id,
+      next_state="ValidateSQLResult")
+
+  @flow.StateHandler()
+  def ValidateSQLResult(self, responses):
+    if not responses.success:
+      self.Log(responses.status)
+    else:
+      for response in responses:
+        self.SendReply(response)
+
+  def NotifyAboutEnd(self):
+    self.Notify("ViewObject", self.urn, "SQL Result")
+
+  @flow.StateHandler()
+  def End(self):
+    self.Log("Successfully executed SQL")
+

--- a/grr/server/flows/osquery/scheduledquery.py
+++ b/grr/server/flows/osquery/scheduledquery.py
@@ -9,6 +9,7 @@ Created on April 7, 2018
 from grr.lib.rdfvalues import osquery as rdf_osquery
 from grr.server import flow
 from grr.server import osquery_stubs
+from grr.server.flows.osquery import osqueryCron
 
 
 class ScheduledQuery(flow.GRRFlow):
@@ -25,8 +26,12 @@ class ScheduledQuery(flow.GRRFlow):
       osquery_stubs.ExecuteScheduledQuery,
       query_id=self.args.query_id,
       query=self.args.query,
-      interval=self.args.interval,
+      interval=self.args.interval*60,
       next_state="ValidateSQLResult")
+
+    interval=str(self.args.interval)+"m"
+    cron=osqueryCron.ScheduledQuery()
+    cron.scheduleCron(interval, self.args.query_id, self.client_id, self.token)
 
   @flow.StateHandler()
   def ValidateSQLResult(self, responses):
@@ -42,4 +47,3 @@ class ScheduledQuery(flow.GRRFlow):
   @flow.StateHandler()
   def End(self):
     self.Log("Successfully executed SQL")
-

--- a/grr/server/flows/osquery/scheduledquery.py
+++ b/grr/server/flows/osquery/scheduledquery.py
@@ -1,0 +1,45 @@
+'''
+Created on April 7, 2018
+
+@author: Mohammed Almodawah
+'''
+#!/usr/bin/env python
+"""These are OSQuery related flows."""
+
+from grr.lib.rdfvalues import osquery as rdf_osquery
+from grr.server import flow
+from grr.server import osquery_stubs
+
+
+class ScheduledQuery(flow.GRRFlow):
+  """Retrieve system data from OSQuery"""
+
+  category = "/OSQuery/"
+  behaviours = flow.GRRFlow.behaviours + "BASIC"
+  args_type = rdf_osquery.OSQueryScheduledQueryArgs
+
+  @flow.StateHandler()
+  def Start(self):
+    """Start processing."""
+    self.CallClient(
+      osquery_stubs.ExecuteScheduledQuery,
+      query_id=self.args.query_id,
+      query=self.args.query,
+      interval=self.args.interval,
+      next_state="ValidateSQLResult")
+
+  @flow.StateHandler()
+  def ValidateSQLResult(self, responses):
+    if not responses.success:
+      self.Log(responses.status)
+    else:
+      for response in responses:
+        self.SendReply(response)
+
+  def NotifyAboutEnd(self):
+    self.Notify("ViewObject", self.urn, "SQL Result")
+
+  @flow.StateHandler()
+  def End(self):
+    self.Log("Successfully executed SQL")
+

--- a/grr/server/osquery_stubs.py
+++ b/grr/server/osquery_stubs.py
@@ -13,3 +13,27 @@ class ExecuteOSQuerySQL(ClientActionStub):
 
   in_rdfvalue = rdf_client_osquery.OSQueryRunQueryArgs
   out_rdfvalues = [rdf_client_osquery.OSQueryRunQueryResult]
+
+class ExecuteScheduledQuery(ClientActionStub):
+  """Run an OSQuery"""
+
+  in_rdfvalue = rdf_client_osquery.OSQueryScheduledQueryArgs
+  out_rdfvalues = [rdf_client_osquery.OSQueryScheduledQueryResult]
+
+class ExecuteRemoveScheduledQuery(ClientActionStub):
+  """Run an OSQuery"""
+
+  in_rdfvalue = rdf_client_osquery.OSQueryRemoveScheduledQueryArgs
+  out_rdfvalues = [rdf_client_osquery.OSQueryRemoveScheduledQueryResult]
+
+class ExecuteListScheduledQueries(ClientActionStub):
+  """Run an OSQuery"""
+
+  in_rdfvalue = None
+  out_rdfvalues = [rdf_client_osquery.OSQueryListScheduledQueriesResult]
+
+class ExecutePullScheduledQuery(ClientActionStub):
+  """Run an OSQuery"""
+
+  in_rdfvalue = rdf_client_osquery.OSQueryPullScheduledQueryArgs
+  out_rdfvalues = [rdf_client_osquery.OSQueryPullScheduledQueryResult]


### PR DESCRIPTION
Implements a REST service, configures and launches osqueryd to use the
REST service for communicating with GRR.
The simple RunQuery flow has been refactored to work with the service.
Occasionally the GRR client nanny kills the client due to memory
pressures???.  Still need to investigate this

